### PR TITLE
chore: move coverage generation to acceptance tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,26 +60,6 @@ jobs:
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
 
-  unit-test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.21'
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Run unit-test
-        run: |
-          go test -race -covermode=atomic -coverprofile=coverage.out ./...
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
   # run acceptance tests in a matrix with Terraform core versions
   test:
     name: Matrix Test
@@ -151,6 +131,14 @@ jobs:
         DRONE_TOKEN: 5PVYqFHjdYWpzyOk6PVj9OUQULibBJeL
         DRONE_USER: terraform
       run: make testacc
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        TERRAFORM_VERSION: ${{ matrix.terraform }}
+      with:
+        env_vars: TERRAFORM_VERSION
 
     - name: Stop the acceptance test stack
       if: always()

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -29,4 +29,4 @@ test:
 
 # Run acceptance tests
 testacc:
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -coverprofile=coverage.out -race -covermode=atomic


### PR DESCRIPTION
## Changes
 - Remove unit test as separated step (see #85)
 - Move code coverage generation to acceptance tests