### PR TITLE
fix: fix error message when user is missing in drone_user data source

### DIFF
--- a/internal/provider/data_source_user.go
+++ b/internal/provider/data_source_user.go
@@ -56,7 +56,7 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, m interface
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  fmt.Sprintf("Failed to read Drone user with id: %s", d.Id()),
+			Summary:  fmt.Sprintf("Failed to read Drone user with id: %s", login),
 			Detail:   err.Error(),
 		})
 

--- a/internal/provider/data_source_user_test.go
+++ b/internal/provider/data_source_user_test.go
@@ -102,8 +102,10 @@ func TestAccDroneUserDataSource(t *testing.T) {
 			Providers: testProviders,
 			Steps: []resource.TestStep{
 				{
-					Config:      configData,
-					ExpectError: regexp.MustCompile("client error 404"), // TODO: find a better error to catch messages
+					Config: configData,
+					ExpectError: regexp.MustCompile(
+						fmt.Sprintf("Error: Failed to read Drone user with id: %s", testMissingUserName),
+					),
 				},
 			},
 		})

--- a/internal/provider/data_source_users.go
+++ b/internal/provider/data_source_users.go
@@ -54,7 +54,6 @@ func dataSourceUsersRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	sort.Strings(logins)
 	d.Set("logins", logins)
-
 	d.SetId(utils.BuildChecksumID(id))
 
 	return diags


### PR DESCRIPTION
## Changes
 - Specify the name of user that is missing in the `drone_user` data source
 - Improve test for `drone_user` data source