### PR TITLE
test: add standard name and checks in acceptance tests

### DIFF
--- a/internal/provider/data_source_repo_test.go
+++ b/internal/provider/data_source_repo_test.go
@@ -26,6 +26,7 @@ func TestAccDroneRepoDataSource(t *testing.T) {
 		`, testOrg, testRepoName)
 
 		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
 			Providers: testProviders,
 			Steps: []resource.TestStep{
 				{

--- a/internal/provider/data_source_repos_test.go
+++ b/internal/provider/data_source_repos_test.go
@@ -33,6 +33,7 @@ func TestAccDroneReposDataSource(t *testing.T) {
 		`
 
 		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
 			Providers: testProviders,
 			Steps: []resource.TestStep{
 				{

--- a/internal/provider/data_source_template_test.go
+++ b/internal/provider/data_source_template_test.go
@@ -29,6 +29,7 @@ func TestAccDroneTemplateDataSource(t *testing.T) {
 		`, testOrg, templateName)
 
 		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
 			Providers: testProviders,
 			Steps: []resource.TestStep{
 				{

--- a/internal/provider/data_source_templates_test.go
+++ b/internal/provider/data_source_templates_test.go
@@ -39,6 +39,7 @@ func TestAccDroneTemplatesDataSource(t *testing.T) {
 		`, testOrg)
 
 		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
 			Providers: testProviders,
 			Steps: []resource.TestStep{
 				{

--- a/internal/provider/data_source_user_self_test.go
+++ b/internal/provider/data_source_user_self_test.go
@@ -15,6 +15,7 @@ func TestAccDroneUserSelfDataSource(t *testing.T) {
 		`
 
 		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
 			Providers: testProviders,
 			Steps: []resource.TestStep{
 				{

--- a/internal/provider/data_source_user_test.go
+++ b/internal/provider/data_source_user_test.go
@@ -68,6 +68,7 @@ func TestAccDroneUserDataSource(t *testing.T) {
 		`, machineName)
 
 		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
 			Providers: testProviders,
 			Steps: []resource.TestStep{
 				{

--- a/internal/provider/data_source_users_test.go
+++ b/internal/provider/data_source_users_test.go
@@ -32,6 +32,7 @@ func TestAccDroneUsersDataSource(t *testing.T) {
 		`
 
 		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
 			Providers: testProviders,
 			Steps: []resource.TestStep{
 				{

--- a/internal/provider/resource_orgsecret_test.go
+++ b/internal/provider/resource_orgsecret_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestOrgSecret(t *testing.T) {
+func TestAccDroneorgSecretResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testProviders,

--- a/internal/provider/resource_repo_test.go
+++ b/internal/provider/resource_repo_test.go
@@ -18,7 +18,7 @@ func testRepoConfigBasic(user, repo string) string {
     `, user, repo)
 }
 
-func TestRepo(t *testing.T) {
+func TestAccDroneRepoResource(t *testing.T) {
 	repoName := "repo-test-1"
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_secret_test.go
+++ b/internal/provider/resource_secret_test.go
@@ -29,7 +29,7 @@ func testSecretConfigBasic(user, repo, name, value string) string {
 	)
 }
 
-func TestSecret(t *testing.T) {
+func TestAccDroneSecretResource(t *testing.T) {
 	repoName := "repo-test-1"
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_template_test.go
+++ b/internal/provider/resource_template_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestTemplate(t *testing.T) {
+func TestAccDroneTemplateResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testProviders,

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -18,7 +18,7 @@ resource "drone_user" "octocat" {
 }
 `
 
-func TestUser(t *testing.T) {
+func TestAccDroneUserResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testProviders,


### PR DESCRIPTION
## Changes
 - Use standard name `TestAcc*` as suggested in the [Terraform doc](https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests#test-files)
 - Add pre-check in all the tests to validate the presence of the required env vars