### PR TITLE
chore: enforce latest version fo go is used for build & release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: '1.21'
+        check-latest: true
       id: go
 
     - name: Check out code into the Go module directory
@@ -50,6 +51,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.21'
+          check-latest: true
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.21'
+          check-latest: true
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
SSIA