### PR TITLE
chore(ci): install terraform as missing in GH workers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+      id: checkout
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -33,8 +36,9 @@ jobs:
         check-latest: true
       id: go
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+      id: terraform
 
     - name: Get dependencies
       run: |
@@ -47,14 +51,20 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        id: checkout
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
           check-latest: true
+        id: go
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        id: terraform
 
       - name: Use go to auto-generate code
         run: go generate ./...
@@ -90,19 +100,14 @@ jobs:
           - '1.8.*'
           - '1.9.*'
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
 
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
         go-version: '1.23'
         check-latest: true
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
-
-    - name: Get dependencies
-      run: |
-        go mod download
 
     - name: Setup Terraform ${{ matrix.terraform }}
       uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,28 +18,33 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      -
-        name: Unshallow
+        id: checkout
+
+      - name: Unshallow
         run: git fetch --prune --unshallow
-      -
-        name: Set up Go
+
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
           check-latest: true
-      -
-        name: Import GPG key
+        id: go
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        id: terraform
+
+      - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6
         with:
           # These secrets will need to be configured for the repository:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
-      -
-        name: Run GoReleaser
+
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           version: '~> v2'


### PR DESCRIPTION
The last version of the GHA workers do not install terraform by default, we need it for the `go generate` command, see:
 * https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
 * https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md